### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1770,7 +1770,7 @@
 		<profile>
 			<id>tx_profile</id>
 			<repositories>
-				<repository>
+				<!--<repository>
 					<id>nexus-osc</id>
 					<url>http://maven.oschina.net/content/groups/public/</url>
 					<releases>
@@ -1790,6 +1790,7 @@
 						<enabled>true</enabled>
 					</snapshots>
 				</repository>
+				-->
 				<repository>
 					<id>nexus-tx</id>
 					<url>http://120.24.75.25:8081/nexus/content/groups/public/</url>
@@ -1802,7 +1803,7 @@
 				</repository>
 			</repositories>
 			<pluginRepositories>
-				<pluginRepository>
+				<!--<pluginRepository>
 					<id>nexus-osc</id>
 					<url>http://maven.oschina.net/content/groups/public/</url>
 					<releases>
@@ -1822,6 +1823,7 @@
 						<enabled>true</enabled>
 					</snapshots>
 				</pluginRepository>
+				-->
 				<pluginRepository>
 					<id>nexus-tx</id>
 					<url>http://120.24.75.25:8081/nexus/content/groups/public/</url>


### PR DESCRIPTION
由于oschina已经暂停maven仓库服务。
去除掉其依赖，避免构建中等待浪费时间